### PR TITLE
BIP100: Dynamic maximum block size by miner vote

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,7 +103,8 @@ linux-build
 win32-build
 qa/pull-tester/run-bitcoind-for-test.sh
 qa/pull-tester/tests_config.py
-qa/pull-tester/cache/*
+qa/pull-tester/cache
+qa/pull-tester/cache_bigblock
 qa/pull-tester/test.*/*
 qa/tmp
 cache/

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -127,6 +127,7 @@ if ENABLE_ZMQ:
     testScripts.append('zmq_test.py')
 
 testScriptsExt = [
+    'bip100-sizelimit.py',
     'bip9-softforks.py',
     'bip65-cltv.py',
     'bip65-cltv-p2p.py',

--- a/qa/rpc-tests/.gitignore
+++ b/qa/rpc-tests/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
 cache
+cache_bigblock

--- a/qa/rpc-tests/bip100-sizelimit.py
+++ b/qa/rpc-tests/bip100-sizelimit.py
@@ -30,10 +30,10 @@ class BigBlockTest(BitcoinTestFramework):
             # Node 3 creates empty blocks that do not vote for increase
             self.nodes = []
             # Use node0 to mine blocks for input splitting
-            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
-            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
-            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
-            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
+            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=2", "-limitancestorsize=2000", "-limitdescendantsize=2000"]))
 
             connect_nodes_bi(self.nodes, 0, 1)
             connect_nodes_bi(self.nodes, 1, 2)
@@ -47,39 +47,45 @@ class BigBlockTest(BitcoinTestFramework):
             blocks = []
             blocks.append(self.nodes[1].generate(503))
             assert(self.sync_blocks(self.nodes[1:3]))
-            blocks.append(self.nodes[2].generate(503))
+            blocks.append(self.nodes[2].generate(502)) # <--- genesis is 503rd vote for 1MB
             assert(self.sync_blocks(self.nodes[2:4]))
-            blocks.append(self.nodes[3].generate(502)) # <--- genesis is 503rd vote for 1MB
+            blocks.append(self.nodes[3].generate(503))
             assert(self.sync_blocks(self.nodes[1:4]))
             blocks.append(self.nodes[1].generate(503))
             assert(self.sync_blocks(self.nodes))
 
-            # Generate 1200 addresses
-            addresses = [ self.nodes[3].getnewaddress() for i in range(0,1200) ]
-
-            amount = Decimal("0.00125")
-
-            send_to = { }
-            for address in addresses:
-                send_to[address] = amount
-
             tx_file = open(os.path.join(CACHE_DIR, "txdata"), "w")
 
-            # Create four megabytes worth of transactions ready to be
-            # mined:
-            print("Creating 100 40K transactions (4MB)")
-            for node in range(1,3):
-                for i in range(0,50):
-                    txid = self.nodes[node].sendmany("", send_to, 1)
-                    txdata = self.nodes[node].getrawtransaction(txid)
-                    tx_file.write(txdata+"\n")
+            # Create a lot of tansaction data ready to be mined
+            fee = Decimal('.00005')
+            used = set()
+            print("Creating transaction data")
+            for i in range(0,25):
+                inputs = []
+                outputs = {}
+                limit = 0
+                utxos = self.nodes[3].listunspent(0)
+                for utxo in utxos:
+                    if not utxo["txid"]+str(utxo["vout"]) in used:
+                        raw_input = {}
+                        raw_input["txid"] = utxo["txid"]
+                        raw_input["vout"] = utxo["vout"]
+                        inputs.append(raw_input)
+                        outputs[self.nodes[3].getnewaddress()] = utxo["amount"] - fee
+                        used.add(utxo["txid"]+str(utxo["vout"]))
+                        limit = limit + 1
+                        if (limit >= 250):
+                            break
+                rawtx = self.nodes[3].createrawtransaction(inputs, outputs)
+                txdata = self.nodes[3].signrawtransaction(rawtx)["hex"]
+                self.nodes[3].sendrawtransaction(txdata)
+                tx_file.write(txdata+"\n")
             tx_file.close()
 
             stop_nodes(self.nodes)
             wait_bitcoinds()
             self.nodes = []
             for i in range(4):
-                os.remove(log_filename(CACHE_DIR, i, "debug.log"))
                 os.remove(log_filename(CACHE_DIR, i, "db.log"))
                 os.remove(log_filename(CACHE_DIR, i, "peers.dat"))
                 os.remove(log_filename(CACHE_DIR, i, "fee_estimates.dat"))
@@ -90,7 +96,7 @@ class BigBlockTest(BitcoinTestFramework):
             shutil.copytree(from_dir, to_dir)
             initialize_datadir(self.options.tmpdir, i) # Overwrite port/rpcport in bitcoin.conf
 
-    def sync_blocks(self, rpc_connections, wait=1, max_wait=30):
+    def sync_blocks(self, rpc_connections, wait=1, max_wait=60):
         """
         Wait until everybody has the same block count
         """
@@ -104,31 +110,26 @@ class BigBlockTest(BitcoinTestFramework):
     def setup_network(self):
         self.nodes = []
 
-        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
-        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
-        self.nodes.append(start_node(3, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=1", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60))
+        # (We don't restart the node with the huge wallet
         connect_nodes_bi(self.nodes, 0, 1)
         connect_nodes_bi(self.nodes, 1, 2)
-        connect_nodes_bi(self.nodes, 2, 3)
-        connect_nodes_bi(self.nodes, 3, 0)
+        connect_nodes_bi(self.nodes, 2, 0)
 
-        # Populate node0's mempool with cached pre-created transactions:
+        self.load_mempool(self.nodes[0])
+
+    def load_mempool(self, node):
         with open(os.path.join(CACHE_DIR, "txdata"), "r") as f:
             for line in f:
-                self.nodes[0].sendrawtransaction(line.rstrip())
-
-    def copy_mempool(self, from_node, to_node):
-        txids = from_node.getrawmempool()
-        for txid in txids:
-            txdata = from_node.getrawtransaction(txid)
-            to_node.sendrawtransaction(txdata)
+                node.sendrawtransaction(line.rstrip())
 
     def TestMineBig(self, expect_big):
         # Test if node0 will mine a block bigger than legacy MAX_BLOCK_SIZE
         b1hash = self.nodes[0].generate(1)[0]
         b1 = self.nodes[0].getblock(b1hash, True)
-        assert(self.sync_blocks(self.nodes))
+        assert(self.sync_blocks(self.nodes[0:3]))
 
         if expect_big:
             assert(b1['size'] > 1000*1000)
@@ -138,22 +139,18 @@ class BigBlockTest(BitcoinTestFramework):
             b2hash = self.nodes[1].generate(1)[0]
             b2 = self.nodes[1].getblock(b2hash, True)
             assert(b2['previousblockhash'] == b1hash)
-            assert(self.sync_blocks(self.nodes))
+            assert(self.sync_blocks(self.nodes[0:3]))
 
         else:
             assert(b1['size'] < 1000*1000)
 
         # Reset chain to before b1hash:
-        for node in self.nodes:
+        for node in self.nodes[0:3]:
             node.invalidateblock(b1hash)
-        assert(self.sync_blocks(self.nodes))
+        assert(self.sync_blocks(self.nodes[0:3]))
 
 
     def run_test(self):
-        # nodes 0 and 1 have mature 50-BTC coinbase transactions.
-        # Spend them with 50 transactions, each that has
-        # 1,200 outputs (so they're about 41K big).
-
         print("Testing consensus blocksize increase conditions")
 
         assert_equal(self.nodes[0].getblockcount(), 2011) # This is a 0-based height
@@ -163,8 +160,8 @@ class BigBlockTest(BitcoinTestFramework):
         self.TestMineBig(False)
 
         # Create a situation where the 1512th-highest vote is for 2MB
-        self.nodes[3].generate(1)
-        assert(self.sync_blocks(self.nodes[1:4]))
+        self.nodes[2].generate(1)
+        assert(self.sync_blocks(self.nodes[1:3]))
         ahash = self.nodes[1].generate(3)[2]
         assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
         assert(self.sync_blocks(self.nodes[0:2]))
@@ -172,34 +169,34 @@ class BigBlockTest(BitcoinTestFramework):
 
         # Shutdown then restart node[0], it should produce a big block.
         stop_node(self.nodes[0], 0)
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
-        self.copy_mempool(self.nodes[1], self.nodes[0])
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.load_mempool(self.nodes[0])
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 0, 3)
+        connect_nodes_bi(self.nodes, 0, 2)
         assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
         self.TestMineBig(True)
 
         # Test re-orgs past the sizechange block
         stop_node(self.nodes[0], 0)
-        self.nodes[3].invalidateblock(ahash)
-        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
-        self.nodes[3].generate(2)
-        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
-        assert(self.sync_blocks(self.nodes[1:]))
+        self.nodes[2].invalidateblock(ahash)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        self.nodes[2].generate(2)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        assert(self.sync_blocks(self.nodes[1:3]))
 
         # Restart node0, it should re-org onto longer chain,
         # and refuse to mine a big block:
-        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
-        self.copy_mempool(self.nodes[1], self.nodes[0])
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8", "-limitancestorsize=2000", "-limitdescendantsize=2000"], timewait=60)
+        self.load_mempool(self.nodes[0])
         connect_nodes_bi(self.nodes, 0, 1)
-        connect_nodes_bi(self.nodes, 0, 3)
-        assert(self.sync_blocks(self.nodes))
+        connect_nodes_bi(self.nodes, 0, 2)
+        assert(self.sync_blocks(self.nodes[0:3]))
         assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
         self.TestMineBig(False)
 
-        # Mine 4 blocks voting for 2MB. Bigger block NOT ok, we are in the next voting period
-        self.nodes[2].generate(4)
-        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        # Mine 4 blocks voting for 8MB. Bigger block NOT ok, we are in the next voting period
+        self.nodes[1].generate(4)
+        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], 1000000)
         assert(self.sync_blocks(self.nodes[0:3]))
         self.TestMineBig(False)
 

--- a/qa/rpc-tests/bip100-sizelimit.py
+++ b/qa/rpc-tests/bip100-sizelimit.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+# Copyright (c) 2017 The Bitcoin developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#
+# Test mining and broadcast of larger-than-1MB-blocks
+#
+from test_framework.test_framework import BitcoinTestFramework
+from test_framework.util import *
+
+from decimal import Decimal
+
+CACHE_DIR = "cache_bigblock"
+
+class BigBlockTest(BitcoinTestFramework):
+
+    def setup_chain(self):
+        print("Initializing test directory "+self.options.tmpdir)
+
+        if not os.path.isdir(os.path.join(CACHE_DIR, "node0")):
+            print("Creating initial chain. This will be cached for future runs.")
+
+            for i in range(4):
+                initialize_datadir(CACHE_DIR, i) # Overwrite port/rpcport in bitcoin.conf
+
+            # Node 0 creates 8MB blocks that vote for increase to 8MB
+            # Node 1 creates empty blocks that vote for 8MB
+            # Node 2 creates empty blocks that vote for 2MB
+            # Node 3 creates empty blocks that do not vote for increase
+            self.nodes = []
+            # Use node0 to mine blocks for input splitting
+            self.nodes.append(start_node(0, CACHE_DIR, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
+            self.nodes.append(start_node(1, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
+            self.nodes.append(start_node(2, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
+            self.nodes.append(start_node(3, CACHE_DIR, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+
+            connect_nodes_bi(self.nodes, 0, 1)
+            connect_nodes_bi(self.nodes, 1, 2)
+            connect_nodes_bi(self.nodes, 2, 3)
+            connect_nodes_bi(self.nodes, 3, 0)
+
+            self.is_network_split = False
+
+            # Create a 2012-block chain in a 75% ratio for increase (genesis block votes for 1MB)
+            # Make sure they are not already sorted correctly
+            blocks = []
+            blocks.append(self.nodes[1].generate(503))
+            assert(self.sync_blocks(self.nodes[1:3]))
+            blocks.append(self.nodes[2].generate(503))
+            assert(self.sync_blocks(self.nodes[2:4]))
+            blocks.append(self.nodes[3].generate(502)) # <--- genesis is 503rd vote for 1MB
+            assert(self.sync_blocks(self.nodes[1:4]))
+            blocks.append(self.nodes[1].generate(503))
+            assert(self.sync_blocks(self.nodes))
+
+            # Generate 1200 addresses
+            addresses = [ self.nodes[3].getnewaddress() for i in range(0,1200) ]
+
+            amount = Decimal("0.00125")
+
+            send_to = { }
+            for address in addresses:
+                send_to[address] = amount
+
+            tx_file = open(os.path.join(CACHE_DIR, "txdata"), "w")
+
+            # Create four megabytes worth of transactions ready to be
+            # mined:
+            print("Creating 100 40K transactions (4MB)")
+            for node in range(1,3):
+                for i in range(0,50):
+                    txid = self.nodes[node].sendmany("", send_to, 1)
+                    txdata = self.nodes[node].getrawtransaction(txid)
+                    tx_file.write(txdata+"\n")
+            tx_file.close()
+
+            stop_nodes(self.nodes)
+            wait_bitcoinds()
+            self.nodes = []
+            for i in range(4):
+                os.remove(log_filename(CACHE_DIR, i, "debug.log"))
+                os.remove(log_filename(CACHE_DIR, i, "db.log"))
+                os.remove(log_filename(CACHE_DIR, i, "peers.dat"))
+                os.remove(log_filename(CACHE_DIR, i, "fee_estimates.dat"))
+
+        for i in range(4):
+            from_dir = os.path.join(CACHE_DIR, "node"+str(i))
+            to_dir = os.path.join(self.options.tmpdir,  "node"+str(i))
+            shutil.copytree(from_dir, to_dir)
+            initialize_datadir(self.options.tmpdir, i) # Overwrite port/rpcport in bitcoin.conf
+
+    def sync_blocks(self, rpc_connections, wait=1, max_wait=30):
+        """
+        Wait until everybody has the same block count
+        """
+        for i in range(0,max_wait):
+            if i > 0: time.sleep(wait)
+            counts = [ x.getblockcount() for x in rpc_connections ]
+            if counts == [ counts[0] ]*len(counts):
+                return True
+        return False
+
+    def setup_network(self):
+        self.nodes = []
+
+        self.nodes.append(start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"]))
+        self.nodes.append(start_node(1, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=8"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=2"]))
+        self.nodes.append(start_node(3, self.options.tmpdir, ["-blockmaxsize=1000", "-maxblocksizevote=1"]))
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 1, 2)
+        connect_nodes_bi(self.nodes, 2, 3)
+        connect_nodes_bi(self.nodes, 3, 0)
+
+        # Populate node0's mempool with cached pre-created transactions:
+        with open(os.path.join(CACHE_DIR, "txdata"), "r") as f:
+            for line in f:
+                self.nodes[0].sendrawtransaction(line.rstrip())
+
+    def copy_mempool(self, from_node, to_node):
+        txids = from_node.getrawmempool()
+        for txid in txids:
+            txdata = from_node.getrawtransaction(txid)
+            to_node.sendrawtransaction(txdata)
+
+    def TestMineBig(self, expect_big):
+        # Test if node0 will mine a block bigger than legacy MAX_BLOCK_SIZE
+        b1hash = self.nodes[0].generate(1)[0]
+        b1 = self.nodes[0].getblock(b1hash, True)
+        assert(self.sync_blocks(self.nodes))
+
+        if expect_big:
+            assert(b1['size'] > 1000*1000)
+
+            # Have node1 mine on top of the block,
+            # to make sure it goes along with the fork
+            b2hash = self.nodes[1].generate(1)[0]
+            b2 = self.nodes[1].getblock(b2hash, True)
+            assert(b2['previousblockhash'] == b1hash)
+            assert(self.sync_blocks(self.nodes))
+
+        else:
+            assert(b1['size'] < 1000*1000)
+
+        # Reset chain to before b1hash:
+        for node in self.nodes:
+            node.invalidateblock(b1hash)
+        assert(self.sync_blocks(self.nodes))
+
+
+    def run_test(self):
+        # nodes 0 and 1 have mature 50-BTC coinbase transactions.
+        # Spend them with 50 transactions, each that has
+        # 1,200 outputs (so they're about 41K big).
+
+        print("Testing consensus blocksize increase conditions")
+
+        assert_equal(self.nodes[0].getblockcount(), 2011) # This is a 0-based height
+
+        # Current nMaxBlockSize is still 1MB
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
+        self.TestMineBig(False)
+
+        # Create a situation where the 1512th-highest vote is for 2MB
+        self.nodes[3].generate(1)
+        assert(self.sync_blocks(self.nodes[1:4]))
+        ahash = self.nodes[1].generate(3)[2]
+        assert_equal(self.nodes[1].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
+        assert(self.sync_blocks(self.nodes[0:2]))
+        self.TestMineBig(True)
+
+        # Shutdown then restart node[0], it should produce a big block.
+        stop_node(self.nodes[0], 0)
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
+        self.copy_mempool(self.nodes[1], self.nodes[0])
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 0, 3)
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], int(1000000 * 1.05))
+        self.TestMineBig(True)
+
+        # Test re-orgs past the sizechange block
+        stop_node(self.nodes[0], 0)
+        self.nodes[3].invalidateblock(ahash)
+        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
+        self.nodes[3].generate(2)
+        assert_equal(self.nodes[3].getblocktemplate()["sizelimit"], 1000000)
+        assert(self.sync_blocks(self.nodes[1:]))
+
+        # Restart node0, it should re-org onto longer chain,
+        # and refuse to mine a big block:
+        self.nodes[0] = start_node(0, self.options.tmpdir, ["-blockmaxsize=8000000", "-maxblocksizevote=8"])
+        self.copy_mempool(self.nodes[1], self.nodes[0])
+        connect_nodes_bi(self.nodes, 0, 1)
+        connect_nodes_bi(self.nodes, 0, 3)
+        assert(self.sync_blocks(self.nodes))
+        assert_equal(self.nodes[0].getblocktemplate()["sizelimit"], 1000000)
+        self.TestMineBig(False)
+
+        # Mine 4 blocks voting for 2MB. Bigger block NOT ok, we are in the next voting period
+        self.nodes[2].generate(4)
+        assert_equal(self.nodes[2].getblocktemplate()["sizelimit"], 1000000)
+        assert(self.sync_blocks(self.nodes[0:3]))
+        self.TestMineBig(False)
+
+
+        print("Cached test chain and transactions left in %s"%(CACHE_DIR))
+
+if __name__ == '__main__':
+    BigBlockTest().main()

--- a/qa/rpc-tests/test_framework/authproxy.py
+++ b/qa/rpc-tests/test_framework/authproxy.py
@@ -124,6 +124,11 @@ class AuthServiceProxy(object):
                 return self._get_response()
             else:
                 raise
+        except BrokenPipeError:
+            # Python 3.5+ raises this instead of BadStatusLine when the connection was reset
+            self.__conn.close()
+            self.__conn.request(method, path, postdata, headers)
+            return self._get_response()
 
     def __call__(self, *args):
         AuthServiceProxy.__id_count += 1

--- a/qa/rpc-tests/test_framework/comptool.py
+++ b/qa/rpc-tests/test_framework/comptool.py
@@ -52,6 +52,7 @@ class TestNode(NodeConnCB):
         self.tx_request_map = {}
         self.block_reject_map = {}
         self.tx_reject_map = {}
+        self.inv_hash_ignore = []
 
         # When the pingmap is non-empty we're waiting for 
         # a response
@@ -77,14 +78,16 @@ class TestNode(NodeConnCB):
             conn.send_message(response)
 
     def on_getdata(self, conn, message):
-        [conn.send_message(r) for r in self.block_store.get_blocks(message.inv)]
-        [conn.send_message(r) for r in self.tx_store.get_transactions(message.inv)]
-
-        for i in message.inv:
-            if i.type == 1:
+        for idx, i in enumerate(message.inv):
+            if i.hash in self.inv_hash_ignore:
+                del message.inv[idx]
+            elif i.type == 1:
                 self.tx_request_map[i.hash] = True
             elif i.type == 2:
                 self.block_request_map[i.hash] = True
+
+        [conn.send_message(r) for r in self.block_store.get_blocks(message.inv)]
+        [conn.send_message(r) for r in self.tx_store.get_transactions(message.inv)]
 
     def on_inv(self, conn, message):
         self.lastInv = [x.hash for x in message.inv]
@@ -192,10 +195,10 @@ class TestManager(object):
             return all(node.verack_received for node in self.test_nodes)
         return wait_until(veracked, timeout=10)
 
-    def wait_for_pings(self, counter):
+    def wait_for_pings(self, counter, attempts=float('inf')):
         def received_pongs():
             return all(node.received_ping_response(counter) for node in self.test_nodes)
-        return wait_until(received_pongs)
+        return wait_until(received_pongs, attempts)
 
     # sync_blocks: Wait for all connections to request the blockhash given
     # then send get_headers to find out the tip of each node, and synchronize
@@ -217,7 +220,7 @@ class TestManager(object):
 
         # Send ping and wait for response -- synchronization hack
         [ c.cb.send_ping(self.ping_counter) for c in self.connections ]
-        self.wait_for_pings(self.ping_counter)
+        self.wait_for_pings(self.ping_counter, attempts=20)
         self.ping_counter += 1
 
     # Analogous to sync_block (see above)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -100,6 +100,7 @@ BITCOIN_CORE_H = \
   dbwrapper.h \
   limitedmap.h \
   main.h \
+  maxblocksize.h \
   memusage.h \
   merkleblock.h \
   miner.h \
@@ -181,6 +182,7 @@ libbitcoin_server_a_SOURCES = \
   init.cpp \
   dbwrapper.cpp \
   main.cpp \
+  maxblocksize.cpp \
   merkleblock.cpp \
   miner.cpp \
   net.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -60,6 +60,7 @@ BITCOIN_TESTS =\
   test/miner_tests.cpp \
   test/multisig_tests.cpp \
   test/netbase_tests.cpp \
+  test/p2p_protocol_tests.cpp \
   test/pmt_tests.cpp \
   test/policyestimator_tests.cpp \
   test/pow_tests.cpp \

--- a/src/Makefile.test.include
+++ b/src/Makefile.test.include
@@ -55,6 +55,7 @@ BITCOIN_TESTS =\
   test/limitedmap_tests.cpp \
   test/dbwrapper_tests.cpp \
   test/main_tests.cpp \
+  test/maxblocksize_tests.cpp \
   test/mempool_tests.cpp \
   test/merkle_tests.cpp \
   test/miner_tests.cpp \

--- a/src/alert.cpp
+++ b/src/alert.cpp
@@ -121,7 +121,7 @@ bool CAlert::AppliesTo(int nVersion, const std::string& strSubVerIn) const
 
 bool CAlert::AppliesToMe() const
 {
-    return AppliesTo(PROTOCOL_VERSION, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<std::string>()));
+    return AppliesTo(PROTOCOL_VERSION, FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, std::vector<std::string>(), 0));
 }
 
 bool CAlert::RelayTo(CNode* pnode) const

--- a/src/chain.h
+++ b/src/chain.h
@@ -14,6 +14,9 @@
 
 #include <vector>
 
+static const int BIP100_DBI_VERSION = 0x08000000;
+static const int DISK_BLOCK_INDEX_VERSION = BIP100_DBI_VERSION;
+
 struct CDiskBlockPos
 {
     int nFile;
@@ -67,8 +70,8 @@ enum BlockStatus {
 
     /**
      * Only first tx is coinbase, 2 <= coinbase input script length <= 100, transactions valid, no duplicate txids,
-     * sigops, size, merkle root. Implies all parents are at least TREE but not necessarily TRANSACTIONS. When all
-     * parent blocks also have TRANSACTIONS, CBlockIndex::nChainTx will be set.
+     * merkle root. Implies all parents are at least TREE but not necessarily TRANSACTIONS. When all
+     * parent blocks also have TRANSACTIONS, CBlockIndex::nChainTx and maxblocksize will be set.
      */
     BLOCK_VALID_TRANSACTIONS =    3,
 
@@ -146,6 +149,15 @@ public:
     //! (memory only) Sequential id assigned to distinguish order in which blocks are received.
     uint32_t nSequenceId;
 
+    //! Index entry serial format version
+    int nSerialVersion;
+
+    //! Maximum serialized block size at nHeight
+    uint64_t nMaxBlockSize;
+
+    //! This block's vote for future maximum serialized block size
+    uint64_t nMaxBlockSizeVote;
+
     void SetNull()
     {
         phashBlock = NULL;
@@ -160,6 +172,9 @@ public:
         nChainTx = 0;
         nStatus = 0;
         nSequenceId = 0;
+        nSerialVersion = 0;
+        nMaxBlockSize = 0;
+        nMaxBlockSizeVote = 0;
 
         nVersion       = 0;
         hashMerkleRoot = uint256();
@@ -292,6 +307,7 @@ public:
 
     explicit CDiskBlockIndex(const CBlockIndex* pindex) : CBlockIndex(*pindex) {
         hashPrev = (pprev ? pprev->GetBlockHash() : uint256());
+        nSerialVersion = DISK_BLOCK_INDEX_VERSION;
     }
 
     ADD_SERIALIZE_METHODS;
@@ -299,7 +315,7 @@ public:
     template <typename Stream, typename Operation>
     inline void SerializationOp(Stream& s, Operation ser_action, int nType, int nVersion) {
         if (!(nType & SER_GETHASH))
-            READWRITE(VARINT(nVersion));
+            READWRITE(VARINT(nSerialVersion));
 
         READWRITE(VARINT(nHeight));
         READWRITE(VARINT(nStatus));
@@ -318,6 +334,11 @@ public:
         READWRITE(nTime);
         READWRITE(nBits);
         READWRITE(nNonce);
+
+        if (nSerialVersion >= BIP100_DBI_VERSION) {
+            READWRITE(VARINT(nMaxBlockSize));
+            READWRITE(VARINT(nMaxBlockSizeVote));
+        }
     }
 
     uint256 GetBlockHash() const

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -92,6 +92,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1462060800; // May 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
 
+        // BIP100 defined start height and max block size change critical vote position
+        consensus.bip100ActivationHeight = 449568;
+        consensus.nMaxBlockSizeChangePosition = 1512;
+
         /**
          * The message start string is designed to be unlikely to occur in normal data.
          * The characters are rarely used upper ASCII, not valid as UTF-8, and produce
@@ -185,6 +189,10 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 1456790400; // March 1st, 2016
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 1493596800; // May 1st, 2017
 
+        // BIP100
+        consensus.bip100ActivationHeight = 798336;
+        consensus.nMaxBlockSizeChangePosition = 1512;
+
         pchMessageStart[0] = 0x0b;
         pchMessageStart[1] = 0x11;
         pchMessageStart[2] = 0x09;
@@ -257,6 +265,8 @@ public:
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].bit = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nStartTime = 0;
         consensus.vDeployments[Consensus::DEPLOYMENT_CSV].nTimeout = 999999999999ULL;
+        consensus.bip100ActivationHeight = 0;
+        consensus.nMaxBlockSizeChangePosition = 1512;
 
         pchMessageStart[0] = 0xfa;
         pchMessageStart[1] = 0xbf;

--- a/src/clientversion.cpp
+++ b/src/clientversion.cpp
@@ -7,6 +7,8 @@
 #include "tinyformat.h"
 
 #include <string>
+#include <iomanip>
+#include <cmath>
 
 /**
  * Name of client reported in the 'version' message. Report the same name
@@ -94,8 +96,18 @@ std::string FormatFullVersion()
 /** 
  * Format the subversion field according to BIP 14 spec (https://github.com/bitcoin/bips/blob/master/bip-0014.mediawiki) 
  */
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments)
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint64_t nMaxBlockSize)
 {
+    if (nMaxBlockSize) {
+        // Announce our excessive block acceptence.
+        comments.insert(comments.end(), std::string("BIP100"));
+
+        std::stringstream ss;
+        double dMaxBlockSize = static_cast<double>(nMaxBlockSize) / 1000000;
+        ss << "EB" << std::setprecision(static_cast<int>(std::log10(dMaxBlockSize))+7) << dMaxBlockSize;
+        comments.insert(comments.end(), ss.str());
+    }
+
     std::ostringstream ss;
     ss << "/";
     ss << name << ":" << FormatVersion(nClientVersion);

--- a/src/clientversion.h
+++ b/src/clientversion.h
@@ -50,6 +50,7 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 static const int CLIENT_VERSION =
                            1000000 * CLIENT_VERSION_MAJOR
@@ -63,7 +64,7 @@ extern const std::string CLIENT_DATE;
 
 
 std::string FormatFullVersion();
-std::string FormatSubVersion(const std::string& name, int nClientVersion, const std::vector<std::string>& comments);
+std::string FormatSubVersion(const std::string& name, int nClientVersion, std::vector<std::string> comments, uint64_t nMaxBlockSize);
 
 #endif // WINDRES_PREPROC
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -6,10 +6,16 @@
 #ifndef BITCOIN_CONSENSUS_CONSENSUS_H
 #define BITCOIN_CONSENSUS_CONSENSUS_H
 
-/** The maximum allowed size for a serialized block, in bytes (network rule) */
+#include <stdint.h>
+
+/** Legacy maximum block size */
 static const unsigned int MAX_BLOCK_SIZE = 1000000;
+/** The maximum allowed size for a serialized transaction, in bytes */
+static const unsigned int MAX_TRANSACTION_SIZE = 1000*1000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
-static const unsigned int MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE/50;
+inline uint64_t MaxBlockSigops(uint64_t nMaxBlockSize) {
+    return ((nMaxBlockSize - 1) / 1000000 + 1) * 1000000 / 50;
+}
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -13,8 +13,8 @@ static const unsigned int MAX_BLOCK_SIZE = 1000000;
 /** The maximum allowed size for a serialized transaction, in bytes */
 static const unsigned int MAX_TRANSACTION_SIZE = 1000*1000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
-inline uint64_t MaxBlockSigops(uint64_t nMaxBlockSize) {
-    return ((nMaxBlockSize - 1) / 1000000 + 1) * 1000000 / 50;
+inline uint64_t MaxBlockSigops(uint64_t nBlockSize) {
+    return ((nBlockSize - 1) / 1000000 + 1) * 1000000 / 50;
 }
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -53,6 +53,13 @@ struct Params {
     uint32_t nRuleChangeActivationThreshold;
     uint32_t nMinerConfirmationWindow;
     BIP9Deployment vDeployments[MAX_VERSION_BITS_DEPLOYMENTS];
+    /**
+     * BIP100: One-based position from beginning (end) of the ascending sorted list of max block size
+     * votes in a retarget interval, at which the possible new lower (higher) max block size is read.
+     * 1512 = 75th percentile of 2016
+     */
+    int bip100ActivationHeight;
+    uint32_t nMaxBlockSizeChangePosition;
     /** Proof of work parameters */
     uint256 powLimit;
     bool fPowAllowMinDifficultyBlocks;

--- a/src/init.cpp
+++ b/src/init.cpp
@@ -1139,17 +1139,17 @@ bool AppInit2(boost::thread_group& threadGroup, CScheduler& scheduler)
     RegisterNodeSignals(GetNodeSignals());
 
     // sanitize comments per BIP-0014, format user agent and check total size
-    std::vector<string> uacomments;
     BOOST_FOREACH(string cmt, mapMultiArgs["-uacomment"])
     {
         if (cmt != SanitizeString(cmt, SAFE_CHARS_UA_COMMENT))
             return InitError(strprintf(_("User Agent comment (%s) contains unsafe characters."), cmt));
-        uacomments.push_back(SanitizeString(cmt, SAFE_CHARS_UA_COMMENT));
+        vUAComments.push_back(SanitizeString(cmt, SAFE_CHARS_UA_COMMENT));
     }
-    strSubVersion = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, uacomments);
-    if (strSubVersion.size() > MAX_SUBVERSION_LENGTH) {
+    uint64_t hugeBlock = static_cast<uint64_t>((100000. / 3.) * MAX_BLOCK_SIZE);
+    size_t userAgentLen = FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, hugeBlock).size();
+    if (userAgentLen > MAX_SUBVERSION_LENGTH) {
         return InitError(strprintf(_("Total length of network version string (%i) exceeds maximum length (%i). Reduce the number or size of uacomments."),
-            strSubVersion.size(), MAX_SUBVERSION_LENGTH));
+            userAgentLen, MAX_SUBVERSION_LENGTH));
     }
 
     if (mapArgs.count("-onlynet")) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1591,8 +1591,12 @@ CAmount GetBlockSubsidy(int nHeight, const Consensus::Params& consensusParams)
     return nSubsidy;
 }
 
+bool fForceInitialBlockDownload = false;
 bool IsInitialBlockDownload()
 {
+    if (fForceInitialBlockDownload)
+        return false;
+
     const CChainParams& chainParams = Params();
     LOCK(cs_main);
     if (fImporting || fReindex)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -303,6 +303,12 @@ int GetHeight()
     return chainActive.Height();
 }
 
+int GetMaxBlockSize()
+{
+    LOCK(cs_main);
+    return chainActive.Tip()->nMaxBlockSize;
+}
+
 void UpdatePreferredDownload(CNode* node, CNodeState* state)
 {
     nPreferredDownload -= state->fPreferredDownload;
@@ -572,6 +578,7 @@ void RegisterNodeSignals(CNodeSignals& nodeSignals)
     nodeSignals.SendMessages.connect(&SendMessages);
     nodeSignals.InitializeNode.connect(&InitializeNode);
     nodeSignals.FinalizeNode.connect(&FinalizeNode);
+    nodeSignals.GetMaxBlockSize.connect(&GetMaxBlockSize);
 }
 
 void UnregisterNodeSignals(CNodeSignals& nodeSignals)
@@ -582,6 +589,7 @@ void UnregisterNodeSignals(CNodeSignals& nodeSignals)
     nodeSignals.SendMessages.disconnect(&SendMessages);
     nodeSignals.InitializeNode.disconnect(&InitializeNode);
     nodeSignals.FinalizeNode.disconnect(&FinalizeNode);
+    nodeSignals.GetMaxBlockSize.disconnect(&GetMaxBlockSize);
 }
 
 CBlockIndex* FindForkInGlobalIndex(const CChain& chain, const CBlockLocator& locator)
@@ -4000,7 +4008,7 @@ bool LoadBlockIndex(bool* fRebuildRequired)
     return true;
 }
 
-bool InitBlockIndex(const CChainParams& chainparams) 
+bool InitBlockIndex(const CChainParams& chainparams)
 {
     LOCK(cs_main);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4371,11 +4371,16 @@ std::string GetWarnings(const std::string& strFor)
 //
 
 static std::map<std::string, size_t> maxMessageSizes = boost::assign::map_list_of
-    ("getaddr",0)
-    ("mempool",0)
-    ("ping",8)
-    ("pong",8)
+    // values list the max size of each part of the message payload currently defined/used.
+    // values equate to the max payload size for that respective message type.
+    ("getaddr", 0)
+    ("mempool", 0)
+    ("ping", 8)
+    ("pong", 8)
     ("verack", 0)
+    ("version", 4 + 8 + 8 + (4 + 8 + 16 + 2) + (4 + 8 + 16 + 2) + 8 + (3 + 256) + 4 + 1)
+    ("filterclear", 0)
+    ("reject", (1 + 12) + 1 + (1 + 111) + 32) // this is loose max because the max valid is actually 151 bytes as of BIP 61. see the p2p_protocol_tests unit tests.
     ;
 
 bool static SanityCheckMessage(CNode* peer, const CNetMessage& msg)
@@ -4567,7 +4572,7 @@ void static ProcessGetData(CNode* pfrom, const Consensus::Params& consensusParam
     }
 }
 
-bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived)
+bool ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, int64_t nTimeReceived)
 {
     const CChainParams& chainparams = Params();
     RandAddSeedPerfmon();
@@ -5506,6 +5511,7 @@ bool static ProcessMessage(CNode* pfrom, string strCommand, CDataStream& vRecv, 
             } catch (const std::ios_base::failure&) {
                 // Avoid feedback loops by preventing reject messages from triggering a new reject message.
                 LogPrint("net", "Unparseable reject message received\n");
+                return false;
             }
         }
     }
@@ -5630,7 +5636,7 @@ bool ProcessMessages(CNode* pfrom)
         }
 
         if (!fRet)
-            LogPrintf("%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(strCommand), nMessageSize, pfrom->id);
+            LogPrint("net", "%s(%s, %u bytes) FAILED peer=%d\n", __func__, SanitizeString(strCommand), nMessageSize, pfrom->id);
 
         break;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2262,7 +2262,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     LogPrint("bench", "    - Sanity checks: %.2fms [%.2fs]\n", 0.001 * (nTime1 - nTimeStart), nTimeCheck * 0.000001);
 
     // Block size limit (BIP100)
-    if (block.vtx.size() > pindex->nMaxBlockSize || ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION) > pindex->nMaxBlockSize)
+    if (block.vtx.size() > pindex->nMaxBlockSize)
+        return state.DoS(100, error("%s: size limits failed", __func__), REJECT_INVALID, "bad-vtx-length");
+    uint64_t nBlockSize = ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION);
+    if (nBlockSize > pindex->nMaxBlockSize)
         return state.DoS(100, error("%s: size limits failed", __func__), REJECT_INVALID, "bad-blk-length");
 
     // Do not allow blocks that contain transactions which 'overwrite' older transactions,
@@ -2346,7 +2349,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
 
         nInputs += tx.vin.size();
         nSigOps += GetLegacySigOpCount(tx);
-        if (nSigOps > MaxBlockSigops(pindex->nMaxBlockSize))
+        if (nSigOps > MaxBlockSigops(nBlockSize))
             return state.DoS(100, error("ConnectBlock(): too many sigops"),
                              REJECT_INVALID, "bad-blk-sigops");
 
@@ -2375,7 +2378,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
                 // this is to prevent a "rogue miner" from creating
                 // an incredibly-expensive-to-validate block.
                 nSigOps += GetP2SHSigOpCount(tx, view);
-                if (nSigOps > MaxBlockSigops(pindex->nMaxBlockSize))
+                if (nSigOps > MaxBlockSigops(nBlockSize))
                     return state.DoS(100, error("ConnectBlock(): too many sigops"),
                                      REJECT_INVALID, "bad-blk-sigops");
             }
@@ -3293,6 +3296,14 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
 
     if (fCheckPOW && fCheckMerkleRoot)
         block.fChecked = true;
+
+    unsigned int nSigOps = 0;
+    BOOST_FOREACH(const CTransaction& tx, block.vtx)
+    {
+        nSigOps += GetLegacySigOpCount(tx);
+    }
+    if (nSigOps > MaxBlockSigops(::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION)))
+        return state.DoS(100, error("CheckBlock(): out-of-bounds SigOpCount"), REJECT_INVALID, "bad-blk-sigops", true);
 
     return true;
 }

--- a/src/main.h
+++ b/src/main.h
@@ -216,6 +216,8 @@ bool LoadBlockIndex();
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */
 bool ProcessMessages(CNode* pfrom);
+/** Process a single message from a given node */
+bool ProcessMessage(CNode* pfrom, std::string strCommand, CDataStream& vRecv, int64_t nTimeReceived);
 /**
  * Send queued protocol messages to be sent to a give node.
  *

--- a/src/main.h
+++ b/src/main.h
@@ -119,6 +119,8 @@ static const bool DEFAULT_ENABLE_REPLACEMENT = true;
 
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
+/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
+static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 
 struct BlockHasher
 {

--- a/src/main.h
+++ b/src/main.h
@@ -62,8 +62,8 @@ static const unsigned int DEFAULT_DESCENDANT_LIMIT = 25;
 static const unsigned int DEFAULT_DESCENDANT_SIZE_LIMIT = 101;
 /** Default for -mempoolexpiry, expiration time for mempool transactions in hours */
 static const unsigned int DEFAULT_MEMPOOL_EXPIRY = 72;
-/** The maximum size of a blk?????.dat file (since 0.8) */
-static const unsigned int MAX_BLOCKFILE_SIZE = 0x8000000; // 128 MiB
+/** Minimum number of max-sized blocks in blk?????.dat files */
+static const unsigned int MIN_BLOCKFILE_BLOCKS = 128;
 /** The pre-allocation chunk size for blk?????.dat files (since 0.8) */
 static const unsigned int BLOCKFILE_CHUNK_SIZE = 0x1000000; // 16 MiB
 /** The pre-allocation chunk size for rev?????.dat files (since 0.8) */
@@ -119,8 +119,6 @@ static const bool DEFAULT_ENABLE_REPLACEMENT = true;
 
 /** Maximum number of headers to announce when relaying blocks with headers message.*/
 static const unsigned int MAX_BLOCKS_TO_ANNOUNCE = 8;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 
 struct BlockHasher
 {
@@ -211,7 +209,7 @@ bool LoadExternalBlockFile(const CChainParams& chainparams, FILE* fileIn, CDiskB
 /** Initialize a new block tree database + block data on disk */
 bool InitBlockIndex(const CChainParams& chainparams);
 /** Load the block tree and coins database from disk */
-bool LoadBlockIndex();
+bool LoadBlockIndex(bool* fRebuildRequired);
 /** Unload database information */
 void UnloadBlockIndex();
 /** Process protocol messages received from a given node */

--- a/src/main.h
+++ b/src/main.h
@@ -227,6 +227,7 @@ void ThreadScriptCheck();
 /** Try to detect Partition (network isolation) attacks against us */
 void PartitionCheck(bool (*initialDownloadCheck)(), CCriticalSection& cs, const CBlockIndex *const &bestHeader, int64_t nPowTargetSpacing);
 /** Check whether we are doing an initial block download (synchronizing from disk or network) */
+extern bool fForceInitialBlockDownload;
 bool IsInitialBlockDownload();
 /** Format a string that describes several potential problems detected by the core.
  * strFor can have three values:

--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -62,7 +62,8 @@ uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Par
 
 static uint32_t FindVote(const std::string& coinbase) {
 
-    uint32_t eb_vote = 0;
+    bool eb_vote = false;
+    uint32_t ebVoteMB = 0;
     std::vector<char> curr;
     bool bip100vote = false;
     bool started = false;
@@ -100,8 +101,9 @@ static uint32_t FindVote(const std::string& coinbase) {
             // Look for a EB vote. Keep it, but continue to look for a BIP100/B vote.
             if (!eb_vote && curr.size() > 2 && curr[0] == 'E' && curr[1] == 'B') {
                 try {
-                    eb_vote = boost::lexical_cast<uint32_t>(std::string(
+                    ebVoteMB = boost::lexical_cast<uint32_t>(std::string(
                                    curr.begin() + 2, curr.end()));
+                    eb_vote = true;
                 }
                 catch (const std::exception& e) {
                     LogPrintf("Invalid coinbase EB-vote: %s\n", e.what());
@@ -117,7 +119,7 @@ static uint32_t FindVote(const std::string& coinbase) {
         else
             curr.push_back(s);
     }
-    return eb_vote;
+    return ebVoteMB;
 }
 
 uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight)

--- a/src/maxblocksize.cpp
+++ b/src/maxblocksize.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "maxblocksize.h"
+
+#include "chain.h"
+#include "util.h"
+#include <string>
+#include <boost/lexical_cast.hpp>
+#include <boost/foreach.hpp>
+
+uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Params& params)
+{
+    // BIP100 not active, return legacy max size
+    if (pindexLast == NULL || pindexLast->nHeight < params.bip100ActivationHeight)
+        return MAX_BLOCK_SIZE;
+
+    uint64_t nMaxBlockSize = pindexLast->nMaxBlockSize;
+
+    // Only change once per difficulty adjustment interval
+    if ((pindexLast->nHeight+1) % params.DifficultyAdjustmentInterval() != 0) {
+        return nMaxBlockSize;
+    }
+
+    std::vector<uint64_t> votes;
+    const CBlockIndex *pindexWalk = pindexLast;
+    for (int64_t i = 0; i < params.DifficultyAdjustmentInterval(); i++) {
+        assert(pindexWalk);
+        assert(pindexWalk->nMaxBlockSize == nMaxBlockSize);
+        votes.push_back(pindexWalk->nMaxBlockSizeVote ? pindexWalk->nMaxBlockSizeVote : pindexWalk->nMaxBlockSize);
+        pindexWalk = pindexWalk->pprev;
+    }
+
+    std::sort(votes.begin(),votes.end());
+    uint64_t lowerValue = votes.at(params.nMaxBlockSizeChangePosition - 1);
+    uint64_t raiseValue = votes.at(params.DifficultyAdjustmentInterval() - params.nMaxBlockSizeChangePosition);
+
+    assert(lowerValue >= 1000000); // minimal vote supported is 1MB
+    assert(lowerValue >= raiseValue); // lowerValue comes from a higher sorted position
+
+    uint64_t raiseCap = nMaxBlockSize * 105 / 100;
+    raiseValue = (raiseValue > raiseCap ? raiseCap : raiseValue);
+    if (raiseValue > nMaxBlockSize) {
+        nMaxBlockSize = raiseValue;
+    } else {
+        uint64_t lowerFloor = nMaxBlockSize * 100 / 105;
+        lowerValue = (lowerValue < lowerFloor ? lowerFloor : lowerValue);
+        if (lowerValue < nMaxBlockSize)
+            nMaxBlockSize = lowerValue;
+    }
+
+    if (nMaxBlockSize != pindexLast->nMaxBlockSize) {
+        LogPrintf("GetNextMaxBlockSize RETARGET\n");
+        LogPrintf("Before: %d\n", pindexLast->nMaxBlockSize);
+        LogPrintf("After:  %d\n", nMaxBlockSize);
+    }
+
+    return nMaxBlockSize;
+}
+
+static uint32_t FindVote(const std::string& coinbase) {
+
+    uint32_t eb_vote = 0;
+    std::vector<char> curr;
+    bool bip100vote = false;
+    bool started = false;
+
+    BOOST_FOREACH (char s, coinbase) {
+        if (s == '/') {
+            started = true;
+            // End (or beginning) of a potential vote string.
+
+            if (curr.size() < 2) // Minimum vote string length is 2
+            {
+                bip100vote = false;
+                curr.clear();
+                continue;
+            }
+
+            if (curr.size()==6 && curr[0]=='B' && curr[1]=='I' && curr[2]=='P' &&
+                                  curr[3]=='1' && curr[4]=='0' && curr[5]=='0') {
+                bip100vote = true;
+                curr.clear();
+                continue;
+            }
+
+            // Look for a B vote.
+            if (bip100vote && curr[0] == 'B') {
+                try {
+                    return boost::lexical_cast<uint32_t>(std::string(
+                                curr.begin() + 1, curr.end()));
+                }
+                catch (const std::exception& e) {
+                    LogPrintf("Invalid coinbase B-vote: %s\n", e.what());
+                }
+            }
+
+            // Look for a EB vote. Keep it, but continue to look for a BIP100/B vote.
+            if (!eb_vote && curr.size() > 2 && curr[0] == 'E' && curr[1] == 'B') {
+                try {
+                    eb_vote = boost::lexical_cast<uint32_t>(std::string(
+                                   curr.begin() + 2, curr.end()));
+                }
+                catch (const std::exception& e) {
+                    LogPrintf("Invalid coinbase EB-vote: %s\n", e.what());
+                }
+            }
+
+            bip100vote = false;
+            curr.clear();
+            continue;
+        }
+        else if (!started)
+            continue;
+        else
+            curr.push_back(s);
+    }
+    return eb_vote;
+}
+
+uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight)
+{
+    // Skip encoded height if found at start of coinbase
+    CScript expect = CScript() << nHeight;
+    int searchStart = coinbase.size() >= expect.size() &&
+                      std::equal(expect.begin(), expect.end(), coinbase.begin())
+                      ? expect.size()
+                      :0;
+
+    std::string s(coinbase.begin() + searchStart, coinbase.end());
+
+    if (s.length() < 5) // shortest vote is /EB1/
+        return 0;
+
+
+    return static_cast<uint64_t>(FindVote(s)) * 1000000;
+}

--- a/src/maxblocksize.h
+++ b/src/maxblocksize.h
@@ -1,0 +1,22 @@
+// Copyright (c) 2009-2010 Satoshi Nakamoto
+// Copyright (c) 2009-2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#ifndef BITCOIN_MAXBLOCKSIZE_H
+#define BITCOIN_MAXBLOCKSIZE_H
+
+#include "consensus/consensus.h"
+#include "consensus/params.h"
+#include "script/script.h"
+
+#include <stdint.h>
+
+class CBlockHeader;
+class CBlockIndex;
+
+uint64_t GetNextMaxBlockSize(const CBlockIndex* pindexLast, const Consensus::Params&);
+
+uint64_t GetMaxBlockSizeVote(const CScript &coinbase, int32_t nHeight);
+
+#endif // BITCOIN_MAXBLOCKSIZE_H

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -245,9 +245,11 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
             if (!IsFinalTx(tx, nHeight, nLockTimeCutoff))
                 continue;
 
+            // TODO: with more complexity we could make the block bigger when
+            // sigop-constrained and sigop density in later megabytes is low
             unsigned int nTxSigOps = iter->GetSigOpCount();
-            if (nBlockSigOps + nTxSigOps >= MaxBlockSigops(hardLimit)) {
-                if (nBlockSigOps > MaxBlockSigops(hardLimit) - 2) {
+            if (nBlockSigOps + nTxSigOps >= MaxBlockSigops(nBlockSize)) {
+                if (nBlockSigOps > MaxBlockSigops(nBlockSize) - 2) {
                     break;
                 }
                 continue;

--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -77,7 +77,7 @@ int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParam
 // BIP100 string:
 // - Adds our block size vote (B) if configured.
 // - Adds Excessive Block (EB) string. This announces how big blocks we currently accept.
-static std::vector<unsigned char> BIP100Str(uint64_t hardLimit) {
+std::vector<unsigned char> BIP100Str(uint64_t hardLimit) {
     uint64_t blockVote = GetArg("-maxblocksizevote", 0);
 
     std::stringstream ss;

--- a/src/miner.h
+++ b/src/miner.h
@@ -36,5 +36,6 @@ CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& s
 /** Modify the extranonce in a block */
 void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
+std::vector<unsigned char> BIP100Str(uint64_t hardlimit);
 
 #endif // BITCOIN_MINER_H

--- a/src/miner.h
+++ b/src/miner.h
@@ -34,7 +34,7 @@ void GenerateBitcoins(bool fGenerate, int nThreads, const CChainParams& chainpar
 /** Generate a new block, without valid proof-of-work */
 CBlockTemplate* CreateNewBlock(const CChainParams& chainparams, const CScript& scriptPubKeyIn);
 /** Modify the extranonce in a block */
-void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce);
+void IncrementExtraNonce(CBlock* pblock, const CBlockIndex* pindexPrev, unsigned int& nExtraNonce, uint64_t nMaxBlockSize);
 int64_t UpdateTime(CBlockHeader* pblock, const Consensus::Params& consensusParams, const CBlockIndex* pindexPrev);
 
 #endif // BITCOIN_MINER_H

--- a/src/net.cpp
+++ b/src/net.cpp
@@ -663,12 +663,10 @@ bool CNode::ReceiveMsgBytes(const char *pch, unsigned int nBytes)
             handled = msg.readData(pch, nBytes);
 
         if (handled < 0)
-                return false;
-
-        if (msg.in_data && msg.hdr.nMessageSize > MAX_PROTOCOL_MESSAGE_LENGTH) {
-            LogPrint("net", "Oversized message from peer=%i, disconnecting\n", GetId());
             return false;
-        }
+
+        if (msg.in_data && !g_signals.SanityCheckMessages(this, boost::ref(msg)))
+            return false;
 
         pch += handled;
         nBytes -= handled;

--- a/src/net.h
+++ b/src/net.h
@@ -29,6 +29,7 @@
 
 class CAddrMan;
 class CScheduler;
+class CNetMessage;
 class CNode;
 
 namespace boost {
@@ -43,8 +44,6 @@ static const int TIMEOUT_INTERVAL = 20 * 60;
 static const unsigned int MAX_INV_SZ = 50000;
 /** The maximum number of new addresses to accumulate before announcing. */
 static const unsigned int MAX_ADDR_TO_SEND = 1000;
-/** Maximum length of incoming protocol messages (no message over 2 MiB is currently acceptable). */
-static const unsigned int MAX_PROTOCOL_MESSAGE_LENGTH = 2 * 1024 * 1024;
 /** Maximum length of strSubVer in `version` message */
 static const unsigned int MAX_SUBVERSION_LENGTH = 256;
 /** -listen default */
@@ -108,10 +107,14 @@ struct CombinerAll
     }
 };
 
-// Signals for message handling
+// Signals are used to communicate with higher-level code.
 struct CNodeSignals
 {
     boost::signals2::signal<int ()> GetHeight;
+    // register a handler for this signal to do sanity checks as the bytes of a message are being
+    // received. Note that the message may not be completely read (so this can be
+    // used to prevent DoS attacks using over-size messages).
+    boost::signals2::signal<bool (CNode*, const CNetMessage&), CombinerAll> SanityCheckMessages;
     boost::signals2::signal<bool (CNode*), CombinerAll> ProcessMessages;
     boost::signals2::signal<bool (CNode*), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;

--- a/src/net.h
+++ b/src/net.h
@@ -119,6 +119,7 @@ struct CNodeSignals
     boost::signals2::signal<bool (CNode*), CombinerAll> SendMessages;
     boost::signals2::signal<void (NodeId, const CNode*)> InitializeNode;
     boost::signals2::signal<void (NodeId)> FinalizeNode;
+    boost::signals2::signal<int ()> GetMaxBlockSize;
 };
 
 
@@ -174,8 +175,8 @@ extern CCriticalSection cs_vAddedNodes;
 extern NodeId nLastNodeId;
 extern CCriticalSection cs_nLastNodeId;
 
-/** Subversion as sent to the P2P network in `version` messages */
-extern std::string strSubVersion;
+/** Comments in subversion sent to the P2P network in `version` messages */
+extern std::vector<std::string> vUAComments;
 
 struct LocalServiceInfo {
     int nScore;

--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -14,8 +14,7 @@
 
 class CCoinsViewCache;
 
-/** Default for -blockmaxsize and -blockminsize, which control the range of sizes the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+/** Default for -blockminsize, which controls the minimum size the mining code will create **/
 static const unsigned int DEFAULT_BLOCK_MIN_SIZE = 0;
 /** Default for -blockprioritysize, maximum space for zero/low-fee transactions **/
 static const unsigned int DEFAULT_BLOCK_PRIORITY_SIZE = 0;
@@ -24,7 +23,7 @@ static const unsigned int MAX_STANDARD_TX_SIZE = 100000;
 /** Maximum number of signature check operations in an IsStandard() P2SH script */
 static const unsigned int MAX_P2SH_SIGOPS = 15;
 /** The maximum number of sigops we're willing to relay/mine in a single tx */
-static const unsigned int MAX_STANDARD_TX_SIGOPS = MAX_BLOCK_SIGOPS/5;
+static const unsigned int MAX_STANDARD_TX_SIGOPS = 4000;
 /** Default for -maxmempool, maximum megabytes of mempool memory usage */
 static const unsigned int DEFAULT_MAX_MEMPOOL_SIZE = 300;
 /**

--- a/src/qt/clientmodel.cpp
+++ b/src/qt/clientmodel.cpp
@@ -183,7 +183,7 @@ QString ClientModel::formatFullVersion() const
 
 QString ClientModel::formatSubVersion() const
 {
-    return QString::fromStdString(strSubVersion);
+    return QString::fromStdString(FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, 0));
 }
 
 QString ClientModel::formatBuildDate() const

--- a/src/rpcblockchain.cpp
+++ b/src/rpcblockchain.cpp
@@ -77,6 +77,8 @@ UniValue blockheaderToJSON(const CBlockIndex* blockindex)
     result.push_back(Pair("bits", strprintf("%08x", blockindex->nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("sizelimit", blockindex->nMaxBlockSize));
+    result.push_back(Pair("sizelimitvote", blockindex->nMaxBlockSizeVote));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -118,6 +120,8 @@ UniValue blockToJSON(const CBlock& block, const CBlockIndex* blockindex, bool tx
     result.push_back(Pair("bits", strprintf("%08x", block.nBits)));
     result.push_back(Pair("difficulty", GetDifficulty(blockindex)));
     result.push_back(Pair("chainwork", blockindex->nChainWork.GetHex()));
+    result.push_back(Pair("sizelimit", blockindex->nMaxBlockSize));
+    result.push_back(Pair("sizelimitvote", blockindex->nMaxBlockSizeVote));
 
     if (blockindex->pprev)
         result.push_back(Pair("previousblockhash", blockindex->pprev->GetBlockHash().GetHex()));
@@ -322,6 +326,9 @@ UniValue getblockheader(const UniValue& params, bool fHelp)
             "  \"nonce\" : n,           (numeric) The nonce\n"
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
+            "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
+            "  \"sizelimit\" : n,       (numeric) The block size limit as of this block\n"
+            "  \"sizelimitvote\" : n,   (numeric) This block's size limit vote\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\",      (string) The hash of the next block\n"
             "  \"chainwork\" : \"0000...1f3\"     (string) Expected number of hashes required to produce the current chain (in hex)\n"
@@ -386,6 +393,8 @@ UniValue getblock(const UniValue& params, bool fHelp)
             "  \"bits\" : \"1d00ffff\", (string) The bits\n"
             "  \"difficulty\" : x.xxx,  (numeric) The difficulty\n"
             "  \"chainwork\" : \"xxxx\",  (string) Expected number of hashes required to produce the chain up to this block (in hex)\n"
+            "  \"sizelimit\" : n,       (numeric) The block size limit as of this block\n"
+            "  \"sizelimitvote\" : n,   (numeric) This block's sizelimit vote\n"
             "  \"previousblockhash\" : \"hash\",  (string) The hash of the previous block\n"
             "  \"nextblockhash\" : \"hash\"       (string) The hash of the next block\n"
             "}\n"
@@ -636,6 +645,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
             "  \"chainwork\": \"xxxx\"     (string) total amount of work in active chain, in hexadecimal\n"
             "  \"pruned\": xx,             (boolean) if the blocks are subject to pruning\n"
             "  \"pruneheight\": xxxxxx,    (numeric) heighest block available\n"
+            "  \"sizelimit\" : n,          (numeric) The block size limit as of the last block\n"
             "  \"softforks\": [            (array) status of softforks in progress\n"
             "     {\n"
             "        \"id\": \"xxxx\",        (string) name of softfork\n"
@@ -673,6 +683,7 @@ UniValue getblockchaininfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("verificationprogress",  Checkpoints::GuessVerificationProgress(Params().Checkpoints(), chainActive.Tip())));
     obj.push_back(Pair("chainwork",             chainActive.Tip()->nChainWork.GetHex()));
     obj.push_back(Pair("pruned",                fPruneMode));
+    obj.push_back(Pair("sizelimit",             chainActive.Tip()->nMaxBlockSize));
 
     const Consensus::Params& consensusParams = Params().GetConsensus();
     CBlockIndex* tip = chainActive.Tip();

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -12,6 +12,7 @@
 #include "core_io.h"
 #include "init.h"
 #include "main.h"
+#include "maxblocksize.h"
 #include "miner.h"
 #include "net.h"
 #include "pow.h"
@@ -164,7 +165,8 @@ UniValue generate(const UniValue& params, bool fHelp)
         CBlock *pblock = &pblocktemplate->block;
         {
             LOCK(cs_main);
-            IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce);
+            uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
+            IncrementExtraNonce(pblock, chainActive.Tip(), nExtraNonce, nMaxBlockSize);
         }
         while (!CheckProofOfWork(pblock->GetHash(), pblock->nBits, Params().GetConsensus())) {
             // Yes, there is a chance every nonce could fail to satisfy the -regtest
@@ -601,6 +603,7 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     aMutable.push_back("transactions");
     aMutable.push_back("prevblock");
 
+    uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("capabilities", aCaps));
 
@@ -668,8 +671,8 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     result.push_back(Pair("mintime", (int64_t)pindexPrev->GetMedianTimePast()+1));
     result.push_back(Pair("mutable", aMutable));
     result.push_back(Pair("noncerange", "00000000ffffffff"));
-    result.push_back(Pair("sigoplimit", (int64_t)MAX_BLOCK_SIGOPS));
-    result.push_back(Pair("sizelimit", (int64_t)MAX_BLOCK_SIZE));
+    result.push_back(Pair("sigoplimit", MaxBlockSigops(nMaxBlockSize)));
+    result.push_back(Pair("sizelimit", nMaxBlockSize));
     result.push_back(Pair("curtime", pblock->GetBlockTime()));
     result.push_back(Pair("bits", strprintf("%08x", pblock->nBits)));
     result.push_back(Pair("height", (int64_t)(pindexPrev->nHeight+1)));

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -591,12 +591,14 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
         int index_in_template = i - 1;
         entry.push_back(Pair("fee", pblocktemplate->vTxFees[index_in_template]));
         entry.push_back(Pair("sigops", pblocktemplate->vTxSigOps[index_in_template]));
-
         transactions.push_back(entry);
     }
 
+    uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
+    CScript flags = CScript() << BIP100Str(nMaxBlockSize);
+    flags +=  COINBASE_FLAGS;
     UniValue aux(UniValue::VOBJ);
-    aux.push_back(Pair("flags", HexStr(COINBASE_FLAGS.begin(), COINBASE_FLAGS.end())));
+    aux.push_back(Pair("flags", HexStr(flags.begin(), flags.end())));
 
     arith_uint256 hashTarget = arith_uint256().SetCompact(pblock->nBits);
 
@@ -605,7 +607,6 @@ UniValue getblocktemplate(const UniValue& params, bool fHelp)
     aMutable.push_back("transactions");
     aMutable.push_back("prevblock");
 
-    uint64_t nMaxBlockSize = GetNextMaxBlockSize(chainActive.Tip(), Params().GetConsensus());
     UniValue result(UniValue::VOBJ);
     result.push_back(Pair("capabilities", aCaps));
 

--- a/src/rpcmining.cpp
+++ b/src/rpcmining.cpp
@@ -247,6 +247,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
             "  \"pooledtx\": n              (numeric) The size of the mem pool\n"
             "  \"testnet\": true|false      (boolean) If using testnet or not\n"
             "  \"chain\": \"xxxx\",         (string) current network name as defined in BIP70 (main, test, regtest)\n"
+            "  \"sizelimit\" : n,           (numeric) The block size limit as of the last block\n"
             "}\n"
             "\nExamples:\n"
             + HelpExampleCli("getmininginfo", "")
@@ -267,6 +268,7 @@ UniValue getmininginfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("pooledtx",         (uint64_t)mempool.size()));
     obj.push_back(Pair("testnet",          Params().TestnetToBeDeprecatedFieldRPC()));
     obj.push_back(Pair("chain",            Params().NetworkIDString()));
+    obj.push_back(Pair("sizelimit",        chainActive.Tip()->nMaxBlockSize));
     obj.push_back(Pair("generate",         getgenerate(params, false)));
     return obj;
 }

--- a/src/rpcmisc.cpp
+++ b/src/rpcmisc.cpp
@@ -62,6 +62,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
             "  \"unlocked_until\": ttt,      (numeric) the timestamp in seconds since epoch (midnight Jan 1 1970 GMT) that the wallet is unlocked for transfers, or 0 if the wallet is locked\n"
             "  \"paytxfee\": x.xxxx,         (numeric) the transaction fee set in " + CURRENCY_UNIT + "/kB\n"
             "  \"relayfee\": x.xxxx,         (numeric) minimum relay fee for non-free transactions in " + CURRENCY_UNIT + "/kB\n"
+            "  \"sizelimit\" : n,            (numeric) The block size limit as of the last block\n"
             "  \"errors\": \"...\"           (string) any error messages\n"
             "}\n"
             "\nExamples:\n"
@@ -103,6 +104,7 @@ UniValue getinfo(const UniValue& params, bool fHelp)
     obj.push_back(Pair("paytxfee",      ValueFromAmount(payTxFee.GetFeePerK())));
 #endif
     obj.push_back(Pair("relayfee",      ValueFromAmount(::minRelayTxFee.GetFeePerK())));
+    obj.push_back(Pair("sizelimit",     chainActive.Tip()->nMaxBlockSize));
     obj.push_back(Pair("errors",        GetWarnings("statusbar")));
     return obj;
 }

--- a/src/rpcnet.cpp
+++ b/src/rpcnet.cpp
@@ -466,7 +466,8 @@ UniValue getnetworkinfo(const UniValue& params, bool fHelp)
 
     UniValue obj(UniValue::VOBJ);
     obj.push_back(Pair("version",       CLIENT_VERSION));
-    obj.push_back(Pair("subversion",    strSubVersion));
+    obj.push_back(Pair("subversion",
+        FormatSubVersion(CLIENT_NAME, CLIENT_VERSION, vUAComments, 0)));
     obj.push_back(Pair("protocolversion",PROTOCOL_VERSION));
     obj.push_back(Pair("localservices",       strprintf("%016x", nLocalServices)));
     obj.push_back(Pair("timeoffset",    GetTimeOffset()));

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -12,6 +12,7 @@
 #include "pow.h"
 #include "serialize.h"
 #include "util.h"
+#include "maxblocksize.h"
 
 #include "test/test_bitcoin.h"
 
@@ -78,7 +79,8 @@ BOOST_AUTO_TEST_CASE(TooLargeBlock)
     s << block;
 
     // Test: too large
-    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen+1);
+    size_t nMaxMessageSize = chainActive.Tip()->nMaxBlockSize * 105 / 100;
+    s.resize(nMaxMessageSize + headerLen + 1);
     CNetMessage::FinalizeHeader(s);
 
     BOOST_CHECK(!testNode.ReceiveMsgBytes(&s[0], s.size()));
@@ -86,7 +88,7 @@ BOOST_AUTO_TEST_CASE(TooLargeBlock)
     testNode.vRecvMsg.clear();
 
     // Test: exactly at max:
-    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen);
+    s.resize(nMaxMessageSize + headerLen);
     CNetMessage::FinalizeHeader(s);
 
     BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));

--- a/src/test/ReceiveMsgBytes_tests.cpp
+++ b/src/test/ReceiveMsgBytes_tests.cpp
@@ -1,0 +1,137 @@
+// Copyright (c) 2011-2014 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+//
+// Unit tests for CNode::ReceiveMsgBytes
+//
+
+
+#include "main.h"
+#include "net.h"
+#include "pow.h"
+#include "serialize.h"
+#include "util.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(ReceiveMsgBytes_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(FullMessages)
+{
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params().MessageStart(), "ping", 0);
+    s << (uint64_t)11; // ping nonce
+    CNetMessage::FinalizeHeader(s);
+
+    LOCK(testNode.cs_vRecvMsg);
+
+    // Receive a full 'ping' message
+    {
+        BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(),1UL);
+        CNetMessage& msg = testNode.vRecvMsg[0];
+        BOOST_CHECK(msg.complete());
+        BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
+        uint64_t nonce;
+        msg.vRecv >> nonce;
+        BOOST_CHECK_EQUAL(nonce, (uint64_t)11);
+    }
+
+
+    testNode.vRecvMsg.clear();
+
+    // ...receive it one byte at a time:
+    {
+        for (size_t i = 0; i < s.size(); i++) {
+            BOOST_CHECK(testNode.ReceiveMsgBytes(&s[i], 1));
+        }
+        BOOST_CHECK_EQUAL(testNode.vRecvMsg.size(),1UL);
+        CNetMessage& msg = testNode.vRecvMsg[0];
+        BOOST_CHECK(msg.complete());
+        BOOST_CHECK_EQUAL(msg.hdr.GetCommand(), "ping");
+        uint64_t nonce;
+        msg.vRecv >> nonce;
+        BOOST_CHECK_EQUAL(nonce, (uint64_t)11);
+   }
+}
+
+BOOST_AUTO_TEST_CASE(TooLargeBlock)
+{
+    // Random real block (000000000000dab0130bbcc991d3d7ae6b81aa6f50a798888dfe62337458dc45)
+    // With one tx
+    CBlock block;
+    CDataStream stream(ParseHex("0100000079cda856b143d9db2c1caff01d1aecc8630d30625d10e8b4b8b0000000000000b50cc069d6a3e33e3ff84a5c41d9d3febe7c770fdcc96b2c3ff60abe184f196367291b4d4c86041b8fa45d630101000000010000000000000000000000000000000000000000000000000000000000000000ffffffff08044c86041b020a02ffffffff0100f2052a01000000434104ecd3229b0571c3be876feaac0442a9f13c5a572742927af1dc623353ecf8c202225f64868137a18cdd85cbbb4c74fbccfd4f49639cf1bdc94a5672bb15ad5d4cac00000000"), SER_NETWORK, PROTOCOL_VERSION);
+    stream >> block;
+
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params().MessageStart(), "block", 0);
+    size_t headerLen = s.size();
+    s << block;
+
+    // Test: too large
+    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen+1);
+    CNetMessage::FinalizeHeader(s);
+
+    BOOST_CHECK(!testNode.ReceiveMsgBytes(&s[0], s.size()));
+
+    testNode.vRecvMsg.clear();
+
+    // Test: exactly at max:
+    s.resize(MAX_PROTOCOL_MESSAGE_LENGTH+headerLen);
+    CNetMessage::FinalizeHeader(s);
+
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+}
+
+BOOST_AUTO_TEST_CASE(TooLargeVerack)
+{
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params().MessageStart(), "verack", 0);
+    size_t headerLen = s.size();
+
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+
+    // verack is zero-length, so even one byte bigger is too big:
+    s.resize(headerLen+1);
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+    CNodeStateStats stats;
+    GetNodeStateStats(testNode.GetId(), stats);
+    BOOST_CHECK(stats.nMisbehavior > 0);
+}
+
+BOOST_AUTO_TEST_CASE(TooLargePing)
+{
+    CNode testNode(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    testNode.nVersion = 1;
+
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << CMessageHeader(Params().MessageStart(), "ping", 0);
+    s << (uint64_t)11; // 8-byte nonce
+
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+
+    // Add another nonce, sanity check should fail
+    s << (uint64_t)11; // 8-byte nonce
+    CNetMessage::FinalizeHeader(s);
+    BOOST_CHECK(testNode.ReceiveMsgBytes(&s[0], s.size()));
+    CNodeStateStats stats;
+    GetNodeStateStats(testNode.GetId(), stats);
+    BOOST_CHECK(stats.nMisbehavior > 0);
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -183,8 +183,14 @@ BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_no_vote) {
 
     // missing BIP100 prefix
     BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/B2/"), height));
-
     BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/B8/"), height));
+
+    //Explicit zeros and garbage
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B0/BIP100/B2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/EB0/EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/Bgarbage/B2/"), height));
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(CScript() << to_uchar("/EBgarbage/EB2/"), height));
+
 
     // Test that height is not a part of the vote string.
     // Encoded height in this test ends with /.

--- a/src/test/maxblocksize_tests.cpp
+++ b/src/test/maxblocksize_tests.cpp
@@ -1,0 +1,199 @@
+// Copyright (c) 2017 The Bitcoin developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include <boost/test/unit_test.hpp>
+#include "maxblocksize.h"
+#include "chain.h"
+#include "chainparams.h"
+#include <algorithm>
+#include <boost/foreach.hpp>
+
+BOOST_AUTO_TEST_SUITE(maxblocksize_tests);
+
+void fillBlockIndex(
+        const Consensus::Params& params, std::vector<CBlockIndex>& blockIndexes,
+        bool addVotes, int64_t currMax) {
+
+    int height = params.bip100ActivationHeight;
+    CBlockIndex* prev = NULL;
+    BOOST_FOREACH (CBlockIndex& index, blockIndexes)
+    {
+        index.nHeight = height++;
+        index.nMaxBlockSize = currMax;
+
+        if (addVotes)
+            index.nMaxBlockSizeVote = std::max(
+                (index.nHeight - params.bip100ActivationHeight) * 1000000, 1000000);
+
+        index.pprev = prev;
+        prev = &index;
+    }
+};
+
+BOOST_AUTO_TEST_CASE(get_next_max_blocksize) {
+    const Consensus::Params& params = Params(CBaseChainParams::MAIN).GetConsensus();
+    BOOST_CHECK_EQUAL(1512, params.nMaxBlockSizeChangePosition);
+
+    // Genesis block, legacy block size
+    BOOST_CHECK_EQUAL(MAX_BLOCK_SIZE, GetNextMaxBlockSize(NULL, params));
+
+    const int64_t interval = params.DifficultyAdjustmentInterval();
+
+    // Not at a difficulty adjustment interval,
+    // should not change max block size.
+    {
+        uint64_t currMax = 42 * 1000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, true, currMax);
+        CBlockIndex index;
+
+        BOOST_FOREACH (CBlockIndex& b, blockInterval) {
+            if ((b.nHeight + 1) % interval == 0)
+                continue;
+            BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&b, params));
+
+        }
+    }
+
+    // No block voted. Keep current size.
+    {
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, false, currMax);
+
+        BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&blockInterval.back(), params));
+    }
+
+    // Everyone votes current size. Keep current size.
+    {
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, false, currMax);
+
+        BOOST_FOREACH (CBlockIndex& b, blockInterval)
+            b.nMaxBlockSizeVote = currMax;
+
+        BOOST_CHECK_EQUAL(currMax,
+                GetNextMaxBlockSize(&blockInterval.back(), params));
+    }
+
+    // Everyone votes.
+    // Blocks vote (vote# * 1MB)
+    {
+        // Test raise.
+        uint64_t currMax = 2000000;
+        std::vector<CBlockIndex> blockInterval(interval);
+        fillBlockIndex(params, blockInterval, true, currMax);
+        uint64_t newLimit = GetNextMaxBlockSize(&blockInterval.back(), params);
+        BOOST_CHECK_EQUAL(int(currMax * 1.05), newLimit);
+
+        // Test lower.
+        currMax = 1000 * 2000000;
+        fillBlockIndex(params, blockInterval, true, currMax);
+        newLimit = GetNextMaxBlockSize(&blockInterval.back(), params);
+        BOOST_CHECK_EQUAL(int(currMax / 1.05), newLimit);
+    }
+}
+
+std::vector<unsigned char> to_uchar(const std::string& coinbaseStr) {
+    return std::vector<unsigned char>(coinbaseStr.begin(), coinbaseStr.end());
+}
+
+// If we have an explicit /B/ vote, we read it and ignore /EB/.
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_b) {
+
+    std::vector<unsigned char> vote(to_uchar("/BIP100/B2/EB1/"));
+    int32_t height = 600000;
+
+    // Coinbase as in the internal miner
+    CScript coinbase = CScript() << height << vote << OP_0;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // Coinbase as created with IncrementExtraNonce
+    unsigned int nonce = 1;
+    CScript coinbase_flags;
+    coinbase = (CScript() << height << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // coinbase without height should also work
+    coinbase = (CScript() << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(2000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // can't vote twice, only first one counts.
+    coinbase = (CScript() << to_uchar("/BIP100/B4/EB6/BIP100/B8/"));
+    BOOST_CHECK_EQUAL(4000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // B-votes override EB, even though EB is first.
+    coinbase = (CScript() << to_uchar("/EB6/BIP100/B8/"));
+    BOOST_CHECK_EQUAL(8000000, GetMaxBlockSizeVote(coinbase, height));
+}
+
+// If /B/ is not present, we count /EB/ as a vote.
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_eb) {
+    std::vector<unsigned char> vote(to_uchar("/some data/EB1/"));
+    int32_t height = 600000;
+
+    CScript coinbase = CScript() << height << vote << OP_0;
+    BOOST_CHECK_EQUAL(1000000, GetMaxBlockSizeVote(coinbase, height));
+
+    unsigned int nonce = 1;
+    CScript coinbase_flags;
+    coinbase = (CScript() << height << vote << CScriptNum(nonce)) + coinbase_flags;
+    BOOST_CHECK_EQUAL(1000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // Example of a Bitcoin Unlimited coinbase string
+    coinbase = CScript() << height << to_uchar("/EB16/AD12/a miner comment");
+    BOOST_CHECK_EQUAL(16000000, GetMaxBlockSizeVote(coinbase, height));
+
+    // can't vote twice, only first one counts.
+    coinbase = (CScript() << to_uchar("some data/EB6/EB8/"));
+    BOOST_CHECK_EQUAL(6000000, GetMaxBlockSizeVote(coinbase, height));
+}
+
+BOOST_AUTO_TEST_CASE(get_max_blocksize_vote_no_vote) {
+    int32_t height = 600000;
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << OP_0, height));
+
+    // votes must begin and end with /
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("BIP100/B2/"), height));
+
+    // whitespace is not allowed
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/ EB2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2 /"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB 2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2 /"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/ B2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B 2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100 /B2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/ BIP100/B2/"), height));
+
+    // decimals not supported
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/EB2.2/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << height << to_uchar("/BIP100/B2.2/"), height));
+
+    // missing mb value
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/"), height));
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/EB/"), height));
+
+    // missing BIP100 prefix
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/B2/"), height));
+
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(CScript() << to_uchar("/BIP100/B/B8/"), height));
+
+    // Test that height is not a part of the vote string.
+    // Encoded height in this test ends with /.
+    // Should not be interpreted as /BIP100/B8/
+    CScript coinbase = CScript() << 47;
+    BOOST_CHECK_EQUAL('/', coinbase.back());
+    std::vector<unsigned char> vote = to_uchar("BIP100/B8/");
+    coinbase.insert(coinbase.end(), vote.begin(), vote.end()); // insert instead of << to avoid size being prepended
+    BOOST_CHECK_EQUAL(0, GetMaxBlockSizeVote(coinbase, 47));
+}
+
+BOOST_AUTO_TEST_SUITE_END();

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -401,6 +401,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_bip100str)
     LOCK(cs_main);
 
     // No vote defined. Should only contain EB.
+    mapArgs.erase("-maxblocksizevote");
     std::string c = DefaultCoinbaseStr();
     BOOST_CHECK(c.find("/BIP100/EB1/") != std::string::npos);
     BOOST_CHECK(c.find("/B1/") == std::string::npos);

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -256,6 +256,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
         next->BuildSkip();
+        next->nMaxBlockSize = prev->nMaxBlockSize;
         chainActive.SetTip(next);
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));
@@ -269,6 +270,7 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
         next->pprev = prev;
         next->nHeight = prev->nHeight + 1;
         next->BuildSkip();
+        next->nMaxBlockSize = prev->nMaxBlockSize;
         chainActive.SetTip(next);
     }
     BOOST_CHECK(pblocktemplate = CreateNewBlock(chainparams, scriptPubKey));

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -388,4 +388,27 @@ BOOST_AUTO_TEST_CASE(CreateNewBlock_validity)
     fCheckpointsEnabled = true;
 }
 
+std::string DefaultCoinbaseStr() {
+    const CChainParams& chainparams = Params(CBaseChainParams::MAIN);
+    CScript scriptPubKey = CScript() << ParseHex("04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f") << OP_CHECKSIG;
+    std::auto_ptr<CBlockTemplate> tpl(CreateNewBlock(chainparams, scriptPubKey));
+    CScript coinbase = tpl->block.vtx.at(0).vin.at(0).scriptSig;
+    return std::string(coinbase.begin(), coinbase.end());
+}
+
+BOOST_AUTO_TEST_CASE(CreateNewBlock_bip100str)
+{
+    LOCK(cs_main);
+
+    // No vote defined. Should only contain EB.
+    std::string c = DefaultCoinbaseStr();
+    BOOST_CHECK(c.find("/BIP100/EB1/") != std::string::npos);
+    BOOST_CHECK(c.find("/B1/") == std::string::npos);
+
+    // Vote for 16MB blocks
+    SoftSetArg("-maxblocksizevote", "16");
+    c = DefaultCoinbaseStr();
+    BOOST_CHECK(c.find("/BIP100/B16/EB1/") != std::string::npos);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/p2p_protocol_tests.cpp
+++ b/src/test/p2p_protocol_tests.cpp
@@ -1,0 +1,111 @@
+// Copyright (c) 2011-2015 The Bitcoin Core developers
+// Distributed under the MIT software license, see the accompanying
+// file COPYING or http://www.opensource.org/licenses/mit-license.php.
+
+#include "main.h"
+
+#include "test/test_bitcoin.h"
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_FIXTURE_TEST_SUITE(p2p_protocol_tests, TestingSetup)
+
+BOOST_AUTO_TEST_CASE(MaxSizeVersionMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    nLocalHostNonce = 2; // this trips the version message logic to end shortly after reading the data (which is the focus of this test)
+    s << PROTOCOL_VERSION;
+    s << n.nServices;
+    s << GetTime();
+    s << CAddress(CService("0.0.0.0", 0));
+    s << CAddress(CService("0.0.0.0", 0));
+    s << nLocalHostNonce;
+    s << std::string(256, 'a'); // 256 is the max allowed length in the Bitcoin Core/XT protocol processing code
+    s << n.nStartingHeight;
+    s << n.fRelayTxes;
+    BOOST_CHECK_EQUAL(352, s.size());
+    BOOST_CHECK(ProcessMessage(&n, "version", s, 0));
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeVersionMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    nLocalHostNonce = 2; // this trips the version message logic to end shortly after reading the data (which is the focus of this test)
+    s << PROTOCOL_VERSION;
+    s << n.nServices;
+    s << GetTime();
+    s << CAddress(CService("0.0.0.0", 0));
+    s << CAddress(CService("0.0.0.0", 0));
+    s << nLocalHostNonce;
+    s << std::string(257, 'a'); // invalid, max is 256
+    s << n.nStartingHeight;
+    s << n.fRelayTxes;
+    BOOST_CHECK_EQUAL(353, s.size());
+    BOOST_CHECK_THROW(ProcessMessage(&n, "version", s, 0), std::ios_base::failure);
+}
+
+BOOST_AUTO_TEST_CASE(MaxSizeWeirdRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string(12, 'a'); // not a real command, but it uses the max of 12 here.
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    BOOST_CHECK_EQUAL(126, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(ProcessMessage(&n, "reject", s, 0));
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(MaxSizeValidRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string("block"); // does not use the max of 12, but "block" is the longest command that has a defined extension of 32 bytes
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    s << uint256();
+    BOOST_CHECK_EQUAL(151, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(ProcessMessage(&n, "reject", s, 0));
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeWeirdRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string(13, 'a'); // invalid, max is 12
+    s << (uint8_t)0x10;
+    s << std::string(111, 'a');
+    BOOST_CHECK_EQUAL(127, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(!ProcessMessage(&n, "reject", s, 0)); // check this way since the reject message processing swallows the exception
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_CASE(OverMaxSizeValidRejectMessage)
+{
+    CNode n(INVALID_SOCKET, CAddress(CService("127.0.0.1", 0), NODE_NETWORK));
+    n.nVersion = PROTOCOL_VERSION;
+    CDataStream s(SER_NETWORK, PROTOCOL_VERSION);
+    s << std::string("block");
+    s << (uint8_t)0x10;
+    s << std::string(112, 'a'); // invalid, max is 111
+    s << uint256();
+    BOOST_CHECK_EQUAL(152, s.size());
+    bool temp = fDebug;
+    fDebug = true;
+    BOOST_CHECK(!ProcessMessage(&n, "reject", s, 0)); // check this way since the reject message processing swallows the exception
+    fDebug = temp;
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/test_bitcoin.cpp
+++ b/src/test/test_bitcoin.cpp
@@ -126,7 +126,7 @@ TestChain100Setup::CreateAndProcessBlock(const std::vector<CMutableTransaction>&
         block.vtx.push_back(tx);
     // IncrementExtraNonce creates a valid coinbase and merkleRoot
     unsigned int extraNonce = 0;
-    IncrementExtraNonce(&block, chainActive.Tip(), extraNonce);
+    IncrementExtraNonce(&block, chainActive.Tip(), extraNonce, MAX_BLOCK_SIZE);
 
     while (!CheckProofOfWork(block.GetHash(), block.nBits, chainparams.GetConsensus())) ++block.nNonce;
 

--- a/src/test/util_tests.cpp
+++ b/src/test/util_tests.cpp
@@ -11,6 +11,7 @@
 #include "utilstrencodings.h"
 #include "utilmoneystr.h"
 #include "test/test_bitcoin.h"
+#include "consensus/consensus.h"
 
 #include <stdint.h>
 #include <vector>
@@ -419,9 +420,15 @@ BOOST_AUTO_TEST_CASE(test_FormatSubVersion)
     std::vector<std::string> comments2;
     comments2.push_back(std::string("comment1"));
     comments2.push_back(SanitizeString(std::string("Comment2; .,_?@-; !\"#$%&'()*+/<=>[]\\^`{|}~"), SAFE_CHARS_UA_COMMENT)); // Semicolon is discouraged but not forbidden by BIP-0014
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>()),std::string("/Test:0.9.99/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments),std::string("/Test:0.9.99(comment1)/"));
-    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>(), 0),std::string("/Test:0.9.99/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments, 0),std::string("/Test:0.9.99(comment1)/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments2, 0),std::string("/Test:0.9.99(comment1; Comment2; .,_?@-; )/"));
+
+    // BIP100
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, std::vector<std::string>(), MAX_BLOCK_SIZE),std::string("/Test:0.9.99(BIP100; EB1)/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments, MAX_BLOCK_SIZE),std::string("/Test:0.9.99(comment1; BIP100; EB1)/"));
+    BOOST_CHECK_EQUAL(FormatSubVersion("Test", 99900, comments, MAX_BLOCK_SIZE + (MAX_BLOCK_SIZE / 3)),
+            std::string("/Test:0.9.99(comment1; BIP100; EB1.333333)/"));
 }
 
 BOOST_AUTO_TEST_CASE(test_ParseFixedPoint)

--- a/src/txdb.cpp
+++ b/src/txdb.cpp
@@ -202,6 +202,9 @@ bool CBlockTreeDB::LoadBlockIndexGuts()
                 pindexNew->nNonce         = diskindex.nNonce;
                 pindexNew->nStatus        = diskindex.nStatus;
                 pindexNew->nTx            = diskindex.nTx;
+                pindexNew->nSerialVersion = diskindex.nSerialVersion;
+                pindexNew->nMaxBlockSize  = diskindex.nMaxBlockSize;
+                pindexNew->nMaxBlockSizeVote = diskindex.nMaxBlockSizeVote;
 
                 if (!CheckProofOfWork(pindexNew->GetBlockHash(), pindexNew->nBits, Params().GetConsensus()))
                     return error("LoadBlockIndex(): CheckProofOfWork failed: %s", pindexNew->ToString());


### PR DESCRIPTION
These changes are for Bitcoin Core 0.12.  For the XT version, see https://github.com/bitcoinxt/bitcoinxt/pull/188.

Implementation of the [BIP100 specification](https://github.com/jgarzik/bip100/blob/master/bip-0100.mediawiki) as published.

Full nodes need no configuration to follow the network sizelimit as determined by BIP100.  Miners may set their coinbase /B vote using 

``-maxblocksizevote=<n> Set vote for maximum block size in megabytes (default: network sizelimit)``

Most RPC's return the sizelimit as of the current tip, consistent with the other attributes.  ``getblocktemplate`` returns the sizelimit for a block built on the current tip, which may change by a factor of up to 1.05 at the start of a difficulty interval, per the specification.

On first run, block index entries starting at the activation height (449568, which was in January 2017) are updated to track miner size votes and sizelimit history.  Use ``-debug=reindex`` (NOT ``-reindex``) to see the progress of this update.

The current network sizelimit is published in the user agent string as EB.

This implementation does not lift the 32MB physical MAX_SIZE limit.  File buffer sizes, sanity checks in bitcoin-tx, verifytxoutproof, outbound bandwidth limiting (core version only), and merkle blocks also continue to reference MAX_BLOCK_SIZE as a general scale indicator.
